### PR TITLE
Fileshare fix2

### DIFF
--- a/www-servers/fileshare/fileshare-9999.ebuild
+++ b/www-servers/fileshare/fileshare-9999.ebuild
@@ -12,7 +12,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-DEPEND="net-libs/libmicrohttpd[messages]"
+DEPEND="net-libs/libmicrohttpd"
 RDEPEND="${DEPEND}"
 
 src_compile() {

--- a/www-servers/fileshare/fileshare-9999.ebuild
+++ b/www-servers/fileshare/fileshare-9999.ebuild
@@ -5,7 +5,7 @@ inherit git-r3
 DESCRIPTION="A small HTTP Server for quickly sharing files over the network."
 HOMEPAGE="http://git.tkolb.de/fileshare/"
 
-EGIT_REPO_URI="http://git.tkolb.de/fileshare.git"
+EGIT_REPO_URI="https://git.tkolb.de/Public/fileshare.git"
 
 LICENSE="PIZZAWARE"
 SLOT="0"


### PR DESCRIPTION
Required to build fileshare against the most recent portage tree.